### PR TITLE
Avoid extra refresh calls 

### DIFF
--- a/utils/http/client.go
+++ b/utils/http/client.go
@@ -272,9 +272,3 @@ func (cl *OpenapiHttpClient) SetTokens(access string, refresh string) {
 
 	cl.tokens.last_update = time.Now()
 }
-
-func (cl *OpenapiHttpClient) GetDefaultHeaders() map[string]string {
-	cl.tokens.mu.RLock()
-	defer cl.tokens.mu.RUnlock()
-	return map[string]string{auth_field: cl.tokens.access_header_value}
-}


### PR DESCRIPTION
In previous HTTP refresh code, the tokens were computed by an extra refresher goroutine.
This implementation had 1 edge case where the job could be triggered multiple times.
Proposed fix makes use of mutex directly and avoid extra worker.